### PR TITLE
Fix crash on 32-bit systems

### DIFF
--- a/foma/rewrite.c
+++ b/foma/rewrite.c
@@ -103,7 +103,7 @@ struct fsm *fsm_rewrite(struct rewrite_set *all_rules) {
     rb = xxcalloc(1, sizeof(struct rewrite_batch));
     rb->rewrite_set = all_rules;
     rb->num_rules = num_rules;
-    rb->namestrings = xxmalloc(sizeof rb->namestrings * num_rules);
+    rb->namestrings = xxmalloc(sizeof *rb->namestrings * num_rules);
     for (i = 0; i < rb->num_rules; i++) {
 	sprintf(rb->namestrings[i], "@#%04i@", i+1);
     }


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=1109949

On 32-bit systems like i586, the sizeof a pointer is 4
so too little memory was allocated for the following loop

This bug was found while working on reproducible builds for openSUSE.