### PR TITLE
Fix segfault with underscore in var name.

### DIFF
--- a/foma/interface.l
+++ b/foma/interface.l
@@ -352,12 +352,14 @@ NOSPEQ     [\001-\177]{-}[\040\041\043\075]|[\300-\337].|[\340-\357]..|[\360-\36
 
 <REGEX>(;) {
     if (my_yyparse(interfacetext, interfacelineno, g_defines, g_defines_f) == 0) {
+      tempnet = fsm_topsort(fsm_minimize(current_parse));
+      if (tempnet == NULL) {
+        printf("invalid regex detected\n");
       /* regex xxx line */
-      if (pmode == RE) {
-         stack_add(fsm_topsort(fsm_minimize(current_parse)));
+      } else if (pmode == RE) {
+         stack_add(current_parse);
       /* define XXX xxx line */
       } else if (pmode == DE) {
-        tempnet = fsm_topsort(fsm_minimize(current_parse));
         olddef = add_defined(g_defines, tempnet,tempstr);
         if (olddef) {
           printf("redefined %s: ",tempstr);

--- a/foma/topsort.c
+++ b/foma/topsort.c
@@ -41,6 +41,8 @@ struct fsm *fsm_topsort (struct fsm *net) {
     long long grand_pathcount, *pathcount;
     struct fsm_state *fsm, *curr_fsm, *new_fsm;
 
+    if (net == NULL) { return NULL; }
+
     fsm_count(net);
 
     fsm = net->states;


### PR DESCRIPTION
Fixes bug: https://github.com/mhulden/foma/issues/77

When underscore is used as a part of regex definition, it is not parsed correctly, since underscore is reserved symbol, therefore NULL FSM net is returned from `my_yyparse` method. But NULL check is not performed before applying topological sorting to NULL FSM. Also NULL check is not performed before adding FSM to the stack. Both cases lead to segmentation fault.

See also GDB debug session output:

```
foma[0]: regex A_B ;

Breakpoint 3, interfacelex () at interface.l:357
357	         stack_add(fsm_topsort(fsm_minimize(current_parse)));
(gdb) n
358	      /* define XXX xxx line */
(gdb) n

Breakpoint 1, fsm_count (net=net@entry=0x0) at constructions.c:1236
1236	void fsm_count(struct fsm *net) {
(gdb) bt
#0  fsm_count (net=net@entry=0x0) at constructions.c:1236
#1  0x0000555555576476 in fsm_topsort (net=0x0) at topsort.c:44
#2  0x0000555555568578 in interfacelex () at interface.l:358
#3  0x000055555555a352 in main (argc=<optimized out>, argv=<optimized out>) at foma.c:183
(gdb) n

Program received signal SIGSEGV, Segmentation fault.
```

This pull request introduces NULL checks in both cases and prints error message if FSM is NULL.