### PR TITLE
Fixed syntax error reporting line count in lexc

### DIFF
--- a/foma/lexc.l
+++ b/foma/lexc.l
@@ -240,6 +240,10 @@ ANY    [\001-\177]|[\300-\337][\200-\277]|[\340-\357][\200-\277][\200-\277]|[\36
   BEGIN(DEFREGEX);
   yymore();
 }
-<*>((!).*[\015]?(\n)) {  /* printf ("Comment: [%s]\n",lexctext); */  }
+<*>((!).*[\015]?(\n)) {
+  /* printf ("Comment: [%s]\n",lexctext); */
+  lexclineno++;
+  lexccolumn = 1;
+}
 
 <*>(.) { printf("\n***Syntax error on line %i column %i at '%s'\n",lexclineno,lexccolumn,lexctext); return 1;}


### PR DESCRIPTION
The flex rule that ate up comments (and the following end line) did not correspondingly increment lexclineno or reset lexccolumn. As a result, some lexc files's syntax errors were reported as being on lines earlier than they actually occurred. I was gonna submit an issue but I figured I'd just take care of it. I'm a little shaky with git, so hopefully I did this right and didn't mess up the project history or anything.

Thanks for reviewing my first real pull request!