### PR TITLE
Makefile now creates libfoma.pc

### DIFF
--- a/foma/Makefile
+++ b/foma/Makefile
@@ -3,6 +3,7 @@ exec_prefix = $(prefix)
 libdir = $(exec_prefix)/lib
 bindir = $(exec_prefix)/bin
 includedir = $(prefix)/include
+pkgcfgdir = $(libdir)/pkgconfig
 
 VERSION = 0.9.18
 CC = gcc
@@ -69,14 +70,16 @@ $(SHAREDLIBV): $(LIBOBJS)
 	$(RANLIB) $(STATICLIB)
 	$(CC) $(CFLAGS) -shared -Wl,$(DFLAG),$(SHAREDLIBM) -o $(SHAREDLIBV) $(LIBOBJS) $(LDFLAGS)
 
-install: foma libfoma
+install: foma libfoma libfoma.pc
 	-@if [ ! -d $(exec_prefix) ]; then mkdir -p $(exec_prefix); fi
 	-@if [ ! -d $(includedir)  ]; then mkdir -p $(includedir); fi
 	-@if [ ! -d $(libdir)      ]; then mkdir -p $(libdir); fi
+	-@if [ ! -d $(pkgcfgdir)   ]; then mkdir -p $(pkgcfgdir); fi
 	-@if [ ! -d $(bindir)      ]; then mkdir -p $(bindir); fi
 	cp fomalib.h fomalibconf.h $(includedir);
 	chmod 644 $(includedir)/fomalib.h
 	cp foma flookup cgflookup $(bindir)
+	cp libfoma.pc $(pkgcfgdir)
 	cp $(LIBS) $(libdir)
 	cd $(libdir); chmod 755 $(LIBS); \
 	if test -f $(libdir)/$(SHAREDLIB); then rm  $(libdir)/$(SHAREDLIB); fi
@@ -86,6 +89,18 @@ install: foma libfoma
 	>/dev/null 2>&1; \
 
 $(OBJS): foma.h
+
+libfoma.pc:
+	echo "prefix=${prefix}" > $@
+	echo 'exec_prefix=$${prefix}' >> $@
+	echo 'includedir=$${prefix}/include' >> $@
+	echo 'libdir=$${exec_prefix}/lib' >> $@
+	echo '' >> $@
+	echo 'Name: foma' >> $@
+	echo 'Description: The foma library' >> $@
+	echo 'Version: ${VERSION}' >> $@
+	echo 'Cflags: -I$${includedir}' >> $@
+	echo 'Libs: -L$${libdir} -lfoma' >> $@
 
 .c.o:
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -106,4 +121,4 @@ regex.c regex.h: regex.y
 	$(YACC) --defines=$*.h --output=$*.c $<
 
 clean:
-	$(RM) foma flookup cgflookup $(FOMAOBJS) $(LIBOBJS) flookup.o cgflookup.o regex.h regex.c regex.output lex.yy.c lex.lexc.c lex.interface.c lex.cmatrix.c *.so* *.dylib* *.a
+	$(RM) foma flookup cgflookup $(FOMAOBJS) $(LIBOBJS) flookup.o cgflookup.o regex.h regex.c regex.output lex.yy.c lex.lexc.c lex.interface.c lex.cmatrix.c *.so* *.dylib* *.a libfoma.pc


### PR DESCRIPTION
This change causes the make install to create and install libfoma.pc.

Various build tools rely on pkg-config to provide the requisite compiler flags needed to compile and link against include files and libraries.

By providing a pkg-config file, foma can be seen and linked against by such tools.

The commit in this pull request was needed in order to get Swift Package Manager to successfully link against libfoma (the goal being a swift wrapper around libfoma).

See also
- https://github.com/dowobeha/Foma
- https://forums.swift.org/t/swift-package-manager-linker-flags-and-dependencies/36943
- https://developer.apple.com/documentation/swift_packages/target/3197895-systemlibrary