### PR TITLE
Various small fixes to foma.py

### DIFF
--- a/foma/python/foma.py
+++ b/foma/python/foma.py
@@ -450,6 +450,10 @@ class MTFSM(FST):
         s += 'Numtapes: %i\n' % self.numtapes
         return s
     
+    def generate(self, word):
+        # TODO: Implement this method
+        raise NotImplementedError()
+
     def parse(self, word):
         #[word/□ .o. [0:?^(numtapes-1) ?]*].l & Grammar ;
         m = self.numtapes

--- a/foma/python/foma.py
+++ b/foma/python/foma.py
@@ -423,7 +423,7 @@ class FST(object):
 class MTFSM(FST):
 
     def __init__(self, regex = False, numtapes = 2):
-        if isinstance(regex, str) or isinstance(regex, unicode):
+        if isinstance(regex, FST.string_type):
             FST.__init__(self, regex)
             eps_sym = FST('□')
             self.fsthandle = foma_fsm_flatten(foma_fsm_copy(self.fsthandle), foma_fsm_copy(eps_sym.fsthandle))
@@ -520,12 +520,12 @@ class MTFSM(FST):
             raise ValueError('FST not defined')
         applyerhandle = foma_apply_init(self.fsthandle)
         toksym = '\x07'
-        foma_apply_set_space_symbol(c_void_p(applyerhandle), c_char_p(toksym))
+        foma_apply_set_space_symbol(c_void_p(applyerhandle), c_char_p(self.encode(toksym)))
         output = applyf(c_void_p(applyerhandle))
         while True:
             if output is None:
                 foma_apply_clear(c_void_p(applyerhandle))
                 return
             else:
-                yield self._fmt(output[:-1].split('\x07'))
+                yield self._fmt(self.decode(output)[:-1].split('\x07'))
             output = applyf(c_void_p(applyerhandle))

--- a/foma/python/foma.py
+++ b/foma/python/foma.py
@@ -134,7 +134,7 @@ class FST(object):
     functiondefinitions = FSTfunctiondefinitions()
 
     # Generalize over Python2 and Python3 types
-    string_types = str   if version_info[0] > 2 else basestring
+    string_type  = str   if version_info[0] > 2 else basestring
     text_type    = str   if version_info[0] > 2 else unicode
     binary_type  = bytes if version_info[0] > 2 else str
 


### PR DESCRIPTION
These fixes were created while attempting to use the MTFSM functionality of foma.py.

This pull request:

- fixes a typo (FST.string_types to FST.string_type)
- updates MTFSM for use with Python3
- adds a stub method for MTFSM.generate, which now needs to be implemented