### PR TITLE
Skip definition without network when save_defined is executed.

### DIFF
--- a/foma/io.c
+++ b/foma/io.c
@@ -572,6 +572,10 @@ int save_defined(struct defined_networks *def, char *filename) {
     }
     printf("Writing definitions to file %s.\n", filename);
     for (d = def; d != NULL; d = d->next) {
+        if (!d->net) {
+            printf("Skipping definition without network.\n");
+            continue;
+        }
         strncpy(d->net->name, d->name, FSM_NAME_LEN);
         foma_net_print(d->net, outfile);
     }


### PR DESCRIPTION
It is needed in order to avoid segfault when save_defined is called and there's only one regex.

See also example debug session output:
```
foma[0]: regex a:b;
228 bytes. 2 states, 1 arc, 1 path.
foma[1]: save defined /tmp/a
Writing definitions to file /tmp/a.

Program received signal SIGSEGV, Segmentation fault.
__strncpy_avx2 () at ../sysdeps/x86_64/multiarch/strcpy-avx2.S:301
301	../sysdeps/x86_64/multiarch/strcpy-avx2.S: No such file or directory.
(gdb) bt
#0  __strncpy_avx2 () at ../sysdeps/x86_64/multiarch/strcpy-avx2.S:301
#1  0x000055555557ce6a in save_defined (def=0x555556e052e0, filename=0x555556e3a0dd "/tmp/a") at io.c:575
#2  0x000055555555da8c in iface_save_defined (filename=0x555556e3a0dd "/tmp/a") at iface.c:1015
#3  0x0000555555565e1e in interfacelex () at interface.l:549
#4  0x00005555555603d6 in my_interfaceparse (my_string=0x555556e05740 "save defined /tmp/a") at interface.l:108
#5  0x000055555555ada3 in main (argc=1, argv=0x7fffffffdba8) at foma.c:183
(gdb) u

```