### PR TITLE
Add runtime options interface

### DIFF
--- a/foma/constructions.c
+++ b/foma/constructions.c
@@ -894,15 +894,17 @@ void fsm_merge_sigma(struct fsm *net1, struct fsm *net2) {
   struct fsm_state *fsm_state, *new_1_state, *new_2_state;
   int i, j, end_1 = 0, end_2 = 0, sigmasizes, *mapping_1, *mapping_2, equal = 1, unknown_1 = 0, unknown_2 = 0, net_unk = 0, net_adds = 0, net_lines;
 
-  i = sigma_find(".#.", net1->sigma);
-  j = sigma_find(".#.", net2->sigma);
-  if (i != -1 && j == -1) {
+  if (!fsm_options.skip_word_boundary_marker) {
+    i = sigma_find(".#.", net1->sigma);
+    j = sigma_find(".#.", net2->sigma);
+    if (i != -1 && j == -1) {
       sigma_add(".#.", net2->sigma);
       sigma_sort(net2);
-  }
-  if (j != -1 && i == -1) {
+    }
+    if (j != -1 && i == -1) {
       sigma_add(".#.", net1->sigma);
       sigma_sort(net1);
+    }
   }
 
   sigma_1 = net1->sigma;

--- a/foma/constructions.c
+++ b/foma/constructions.c
@@ -908,10 +908,10 @@ void fsm_merge_sigma(struct fsm *net1, struct fsm *net2) {
   sigma_1 = net1->sigma;
   sigma_2 = net2->sigma;
 
-  sigmasizes = sigma_size(sigma_1) + sigma_size(sigma_2);
+  sigmasizes = sigma_max(sigma_1) + sigma_max(sigma_2) + 3;
 
-  mapping_1 = xxmalloc(sizeof(int)*(sigmasizes+3));
-  mapping_2 = xxmalloc(sizeof(int)*(sigmasizes+3));
+  mapping_1 = xxmalloc(sizeof(int)*sigmasizes);
+  mapping_2 = xxmalloc(sizeof(int)*sigmasizes);
 
   /* Fill mergesigma */
 

--- a/foma/foma.h
+++ b/foma/foma.h
@@ -24,6 +24,12 @@
 #define PROMPT_MAIN 0 /* Regular prompt */
 #define PROMPT_A 1    /* Apply prompt   */
 
+/** Runtime options */
+struct _fsm_options {
+	_Bool skip_word_boundary_marker;
+};
+extern struct _fsm_options fsm_options;
+
 extern struct defined_networks   *g_defines;
 extern struct defined_functions  *g_defines_f;
 
@@ -34,7 +40,7 @@ struct stack_entry {
   struct apply_med_handle *amedh;
   struct fsm *fsm;
   struct stack_entry *next;
-  struct stack_entry *previous;    
+  struct stack_entry *previous;
 };
 
 /* Quantifier & Logic-related */

--- a/foma/fomalib.h
+++ b/foma/fomalib.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>
+#include <stdbool.h>
 #include "zlib.h"
 
 #define INLINE inline
@@ -198,6 +199,13 @@ int remove_defined (struct defined_networks *def, char *string);
 /********************/
 
 FEXPORT char *fsm_get_library_version_string();
+
+typedef enum {
+	FSMO_SKIP_WORD_BOUNDARY_MARKER, // _Bool
+	FSMO_NUM_OPTIONS
+} FSM_OPTIONS;
+FEXPORT _Bool fsm_set_option(unsigned long long option, void *value);
+FEXPORT void *fsm_get_option(unsigned long long option);
 
 FEXPORT struct fsm *fsm_determinize(struct fsm *net);
 FEXPORT struct fsm *fsm_epsilon_remove(struct fsm *net);

--- a/foma/structures.c
+++ b/foma/structures.c
@@ -22,11 +22,29 @@
 #include "foma.h"
 
 static struct defined_quantifiers *quantifiers;
+struct _fsm_options fsm_options;
 
 char *fsm_get_library_version_string() {
     static char s[20];
     sprintf(s,"%i.%i.%i%s",MAJOR_VERSION,MINOR_VERSION,BUILD_VERSION,STATUS_VERSION);
     return(s);
+}
+
+_Bool fsm_set_option(unsigned long long option, void *value) {
+	switch (option) {
+	case FSMO_SKIP_WORD_BOUNDARY_MARKER:
+		fsm_options.skip_word_boundary_marker = *((_Bool*)value);
+		return 1;
+	}
+	return 0;
+}
+
+void *fsm_get_option(unsigned long long option) {
+	switch (option) {
+	case FSMO_SKIP_WORD_BOUNDARY_MARKER:
+		return &fsm_options.skip_word_boundary_marker;
+	}
+	return NULL;
 }
 
 int linesortcompin(struct fsm_state *a, struct fsm_state *b) {


### PR DESCRIPTION
This PR adds code to fascilitate HFST using Foma directly ( https://github.com/hfst/hfst/issues/485#issuecomment-713512736 & https://github.com/hfst/hfst/tree/foma ).

<s>`sigmasizes+3` to `sigmasizes+30` is trivial - HFST just needs more memory sometimes, and this must be relevant for other users.</s>

But the bigger change is adding API `fsm_set_option()` and `fsm_get_option()` because HFST needs to disable a piece of Foma's code. And I figured if I'm adding a way to set one option, I might as well make it extensible for potential future options.

<s>The option should maybe be renamed - I don't know what the code semantically does, so I named it dot-hash-dot because that's what it mechanically does.</s>

If you can see a better way to accomplish this then by all means do, but this works.