### PR TITLE
clang++ does not define _Bool even with explicit stdbool.h include

### DIFF
--- a/foma/fomalib.h
+++ b/foma/fomalib.h
@@ -27,6 +27,10 @@ extern "C" {
 #include <stdbool.h>
 #include "zlib.h"
 
+#if !defined(bool) && !defined(_Bool)
+  #define _Bool bool
+#endif
+
 #define INLINE inline
 
 #define FEXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
Fallback in case nothing provides `_Bool`