### PR TITLE
Fixed edge case

### DIFF
--- a/foma/python/foma2js.py
+++ b/foma/python/foma2js.py
@@ -120,7 +120,7 @@ def main():
     print()
 
     for key in trans:
-        state, inp = key.split('|')
+        state, inp = key.split('|', maxsplit=1)
         if inp == '@UN@':
             inp = '@ID@'
         print('{}.t[{} + \'|\' + \'{}\'] = [{}];'.format(args.name, state, inp, ','.join(trans[key])))


### PR DESCRIPTION
While converting `babyfst-2020.foma` in https://github.com/asahala/BabyFST, the code in the line fixed returned 3 elements. The fix limits max length of a split result to 2.