### PR TITLE
Fix CMake build failing on std >c18, and add build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ cgflookup
 regex.*
 !regex.l
 *.dylib
+**/CMakeFiles/
+Makefile
+*.so
+*.pc
+*.cmake
+CMake*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# foma
+
+Finite-state transducer technology.
+
+## Compilation Instructions
+
+1. Ensure GNU readline library is installed.
+2. `cd foma`
+3. `cmake CMakeLists.txt`
+4. `make`
+5. `make install` (if you want to install it)

--- a/foma/CMakeLists.txt
+++ b/foma/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
 
 	# Require latest possible C standard
 	include(CheckCCompilerFlag)
-	foreach(flag "-std=c2x" "-std=c18" "-std=c17" "-std=c11" "-std=c1x" "-std=c99")
+	foreach(flag "-std=c18" "-std=c17" "-std=c11" "-std=c1x" "-std=c99")
 		string(REGEX REPLACE "[^a-z0-9]" "" _flag ${flag})
 		CHECK_C_COMPILER_FLAG(${flag} COMPILER_SUPPORTS_${_flag})
 		if(COMPILER_SUPPORTS_${_flag})


### PR DESCRIPTION
Compilation was breaking using `-std="c2x"` because functions have been defined with implicit parameters, i.e. `void foo();`, and then defined as `void foo(int bar)`, etc. Compiling on C18 works. Function declarations should be moved over to use function prototypes instead of implicit parameter declaration (obsolete since ANSI C was released in 1978).