### PR TITLE
Fix BOM_codes initializer

### DIFF
--- a/foma/io.c
+++ b/foma/io.c
@@ -999,7 +999,7 @@ static BOM BOM_codes[] = {
     { { 0x00, 0x00, 0xFE, 0xFF }, 4, "UTF-32BE" },
     { { 0xFF, 0xFE }, 2, "UTF16-LE" },
     { { 0xFE, 0xFF }, 2, "UTF16-BE" },
-    { NULL, 0, NULL },
+    { { 0, } , 0, NULL },
 };
 
 BOM *check_BOM(char *buffer) {


### PR DESCRIPTION
Future compilers will reject the current initializer:

```
io.c:1002:7: error: initialization of ‘char’ from ‘void *’ makes integer from pointer without a cast
 1002 |     { NULL, 0, NULL },
      |       ^~~~
io.c:1002:16: error: initialization of ‘char’ from ‘void *’ makes integer from pointer without a cast
 1002 |     { NULL, 0, NULL },
      |                ^~~~
io.c:996:26: warning: missing braces around initializer [-Wmissing-braces]
  996 | static BOM BOM_codes[] = {
      |                          ^
io.c:996:26: warning: missing braces around initializer [-Wmissing-braces]
```

The reason is that NULL is usually a pointer constant, which is not a valid expression for a character.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
