### PR TITLE
Fix foma build on FreeBSD

### DIFF
--- a/foma/CMakeLists.txt
+++ b/foma/CMakeLists.txt
@@ -176,6 +176,7 @@ else()
     # Regular foma-bin target
     add_executable(foma-bin foma.c stack.c iface.c ${FLEX_Finterface_OUTPUTS})
     target_link_libraries(foma-bin PRIVATE foma-static ${READLINE_LIBRARIES} ${GETOPT_LIB})
+    target_link_directories(foma-bin PRIVATE ${READLINE_LIBRARY_DIRS})
     set_target_properties(foma-bin PROPERTIES RUNTIME_OUTPUT_NAME foma)
 
 	if(MSYS OR NOT WIN32)

--- a/foma/flookup.c
+++ b/foma/flookup.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include "fomalib.h"
 


### PR DESCRIPTION
These two changes improve the portability of foma, and fix issues I was having getting it to build on FreeBSD.

I'm not very experienced with cmake, so feel free to suggest better ways to handle readline discovery. I tried to keep it to as close as the original code, supporting two different methods (pkg-config on line 62 and manual search on lines 66 to 72). Afaict the latter does not work, since the find_path call for readline.h gives you the directory readline.h lives in (e.g. /usr/local/include/readline) whereas foma.c includes readline/readline.h, but I have kept it in case my understanding is incorrect and it is required by some platforms foma supports.